### PR TITLE
Add compatibility defines so we compile on modern Xen.

### DIFF
--- a/src/project.h
+++ b/src/project.h
@@ -48,6 +48,13 @@
 # include <sys/types.h>
 # include <sys/ioctl.h>
 
+/* These defines are necessary to ensure we work on modern Xen.
+ * Once we don't have to support older versions of Xen, these should be dropped,
+ * and we should move to the new APIs. */
+#define XC_WANT_COMPAT_MAP_FOREIGN_API
+#define XC_WANT_COMPAT_GNTTAB_API
+#define XC_WANT_COMPAT_EVTCHN_API
+
 # include <xenctrl.h>
 # include <xenstore.h>
 


### PR DESCRIPTION
Modern Xen breaks foreign mappings, granting, and event channels into their own libraries. We'll need to update to the new API, when we can-- but for now, adding these defines enables a compatibility shim.
