### PR TITLE
gitignore: create/update them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,78 @@
-*~
-*.o
-*.lo
-*.la
-Makefile
+# http://www.gnu.org/software/automake
+
 Makefile.in
-aclocal-copy/
-aclocal.m4
-autom4te.cache/
-compile
-config.*
-configure
-depcomp
-i586-oe-linux-libtool
-install-sh
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+*-libtool
+
+# Generated Makefile
+# (meta build system like autotools,
+# can automatically generate from config.status script
+# (which is called by configure script))
+Makefile
+
+# C
+*.d
+*.o
+
+# Libraries
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.so
+*.so.*
+
+# Executables
+*.out
+
+# Artefacts
+.libs/
 libxenbackend-config
 libxenbackend.pc
-ltmain.sh
-m4/
-missing
-src/.libs/
-src/stamp-h1
 version.sed
+config.h*
+INSTALL
+example/testlog
+tags


### PR DESCRIPTION
externalsrc depends on a revision created with git add -A. Up to date gitignore would prevent unecessary rebuilds.