### PR TITLE
vkbd grant support without privcmd

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -25,17 +25,14 @@ struct xs_handle *xs_handle = NULL;
 static char domain_path[PATH_BUFSZ];
 static int domain_path_len = 0;
 
-int backend_init(int backend_domid)
+int backend_init_noxc(int backend_domid)
 {
+    xc_handle = NULL;
     char *tmp;
 
     xs_handle = xs_open(XS_UNWATCH_FILTER);
     if (!xs_handle)
         goto fail_xs;
-
-    xc_handle = xc_interface_open(NULL, NULL, 0);
-    if (!xc_handle)
-        goto fail_xc;
 
     xcg_handle = xc_gnttab_open(NULL, 0);
     if (!xcg_handle)
@@ -53,12 +50,25 @@ fail_domainpath:
     xc_gnttab_close(xcg_handle);
     xcg_handle = NULL;
 fail_xcg:
-    xc_interface_close(xc_handle);
-    xc_handle = NULL;
-fail_xc:
     xs_daemon_close(xs_handle);
     xs_handle = NULL;
 fail_xs:
+    return -1;
+}
+
+int backend_init(int backend_domid)
+{
+    int ret = backend_init_noxc(backend_domid);
+    if (ret)
+        return ret;
+
+    xc_handle = xc_interface_open(NULL, NULL, 0);
+    if (xc_handle)
+        return 0;
+
+    xc_interface_close(xc_handle);
+    xc_handle = NULL;
+
     return -1;
 }
 
@@ -402,6 +412,9 @@ void *backend_map_shared_page(xen_backend_t xenback, int devid)
     struct xen_device *xendev = &xenback->devices[devid];
     int mfn;
     int rc;
+
+    if (xc_handle == NULL)
+        return NULL;
 
     rc = xs_read_fe_int(xendev, "page-ref", &mfn);
     if (rc)

--- a/src/backend.c
+++ b/src/backend.c
@@ -431,9 +431,12 @@ void *backend_map_granted_ring(xen_backend_t xenback, int devid)
     int ring;
     int rc;
 
-    rc = xs_read_fe_int(xendev, "ring-ref", &ring);
-    if (rc)
-        return NULL;
+    rc = xs_read_fe_int(xendev, "page-gref", &ring);
+    if (rc) {
+        rc = xs_read_fe_int(xendev, "ring-ref", &ring);
+        if (rc)
+            return NULL;
+    }
 
     return xc_gnttab_map_grant_ref(xcg_handle, xenback->domid,
                                    ring, PROT_READ | PROT_WRITE);

--- a/src/xenbackend.h
+++ b/src/xenbackend.h
@@ -161,6 +161,19 @@ int frontend_scan(xen_backend_t xenback, int devid, const char *node, const char
 int backend_init(int backend_domid);
 
 /**
+ * Initialise the file descriptors required to interact with Xen toolstack
+ * component: xenstore, grant-tables, and retrieve the domain path.
+ * backend_close() is expected to be called to release resources.
+ *
+ * Notably this doesn't use xenctrl.
+ *
+ * @param backend_domid domid of the domain where the backend is handled.
+ *
+ * @return 0 on success, else -1 and pass on /errno/.
+ */
+int backend_init_noxc(int backend_domid);
+
+/**
  * Close file descriptors with Xen toolstack components: xenstore, xenctrl,
  * grant-tables.
  *


### PR DESCRIPTION
This PR allows using libxenbackend without opening /dev/xen/privcmd.  privcmd is very powerful, so removing its use is good for implementing least privilege.

The new backend_init_noxc() only opens grant table and event channel support.  backend_init remains still opening xc_handle/privcmd for backwards compatibility.

The second part is for backend_map_granted_ring() to read page-gref since that is what vkbd is using for it's grant.

With these changes, vglass can switch to only using grants and event channels.  It no longer opens /dev/xen/privcmd.

This was all done in a backwards compatible way.  vGlass is the only user of the library now, as far as I can tell, so it could be trimmed down in a non-backwards compatible way.