### PR TITLE
[libxenbackend] Check val before using it

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -61,7 +61,7 @@ void backend_changed(struct xen_device *xendev, const char *node)
             xenback->ops->backend_changed(xendev->dev, node, val);
 
         /* We were told to close */
-        if (strcmp(node, "state") == 0 && strcmp(val, "5") == 0) {
+        if (strcmp(node, "state") == 0 && val && strcmp(val, "5") == 0) {
             /* The frontend never connected. */
             if (xendev->fe_state == XenbusStateInitialising ||
 		xendev->fe_state == XenbusStateUnknown) {


### PR DESCRIPTION
  It's possible in certain cases for the xs_read for val to return
  null if the otherend closed its xenstore node before it could be
  read.  Make sure we check 'val' before using or freeing it to
  avoid segfaulting.

Signed-off-by: Chris Rogers <crogers122@gmail.com>